### PR TITLE
Use exception attributes instead of subscripting

### DIFF
--- a/SDK.ipynb
+++ b/SDK.ipynb
@@ -132,9 +132,9 @@
     "try:\n",
     "    endpoint = tc.get_endpoint(\"BAD ENDPOINT ID\")\n",
     "except Exception as ex:\n",
-    "    print(\"HTTP Status: %s\" % ex[0])\n",
-    "    print(\"HTTP Error: %s\" % ex[1])\n",
-    "    print(\"HTTP Message: %s\" % ex[2])"
+    "    print(\"HTTP Status: %s\" % ex.http_status)\n",
+    "    print(\"HTTP Error: %s\" % ex.code)\n",
+    "    print(\"HTTP Message: %s\" % ex.message)"
    ]
   },
   {


### PR DESCRIPTION
In Python 2, something like `Exception('zero', 'one', 'two')[1]` will give you `'one'`, but on Python 3, will give you a `TypeError: 'XXX' object is not subscriptable` error.

Switches the error handling example to use named attributes instead, which works on both Python 2 and Python 3.